### PR TITLE
Updating boliga_webscrape_sold.R with str_replace_all to avoid problems with grouping mark read as decimals

### DIFF
--- a/R/boliga_webscrape_sold.R
+++ b/R/boliga_webscrape_sold.R
@@ -27,6 +27,7 @@ boliga_webscrape_sold <- function(min_sale_date, max_sale_date, type, postal_cod
     boliga_base_html %>% 
     rvest::html_node(".listings-found-text") %>% 
     rvest::html_text() %>%
+    stringr::str_replace_all("[,.]") %>%
     readr::parse_number() %>% 
     as.integer()
   


### PR DESCRIPTION
I had problems with the package only loading the first page. I have updated the page_count code to replace all periods and commas to just obtain a clean number.