### PR TITLE
Fixed broken link and HTML changes

### DIFF
--- a/R/boliga_create_base_url.R
+++ b/R/boliga_create_base_url.R
@@ -17,7 +17,7 @@
 #'                        postal_code = 4500)
 #'                        
 boliga_create_base_url <- function(min_sale_year = NULL,
-                                   max_sale_year = format(Sys.Date(), "%Y"),
+                                   max_sale_year = as.numeric(format(Sys.Date(), "%Y")),
                                    type = c("Alle", "Villa", "Rækkehus", "Ejerlejlighed", "Fritidshus", "Landejendom"),
                                    postal_code = NULL){
   

--- a/R/boliga_create_base_url.R
+++ b/R/boliga_create_base_url.R
@@ -2,8 +2,8 @@
 
 #' Function to create the base url for webscraping boliga.
 #' 
-#' @param min_sale_date as.Date(). The minimum sale date.
-#' @param max_sale_date as.Date(). The maximum sale date.
+#' @param min_sale_year as.numeric(). The minimum sale date.
+#' @param max_sale_year as.numeric(). The maximum sale date.
 #' @param type type "Alle", "Villa", "Rækkehus", "Ejerleglighed", "Fritidshus", "Landejendom" 
 #' @param post_no Post number.
 #' 
@@ -11,13 +11,13 @@
 #' 
 #' library(boliga)
 #' 
-#' boliga_create_base_url(min_sale_date = Sys.Date() - 100,
-#'                        max_sale_date = Sys.Date(),
+#' boliga_create_base_url(min_sale_year = Sys.Date() - 100,
+#'                        max_sale_year = Sys.Date(),
 #'                        type = "Fritidshus",
 #'                        postal_code = 4500)
 #'                        
-boliga_create_base_url <- function(min_sale_date = NULL,
-                                   max_sale_date = Sys.Date(),
+boliga_create_base_url <- function(min_sale_year = NULL,
+                                   max_sale_year = format(Sys.Date(), "%Y"),
                                    type = c("Alle", "Villa", "Rækkehus", "Ejerlejlighed", "Fritidshus", "Landejendom"),
                                    postal_code = NULL){
   
@@ -30,21 +30,21 @@ boliga_create_base_url <- function(min_sale_date = NULL,
     
     base_url <- paste0(base_url, sort_by)
   }
-  
-  if(!is.null(min_sale_date) | class(min_sale_date)[1] == "Date"){
-    min_sale_date <- paste0("&minsaledate=", min_sale_date)
+
+  if(!is.null(min_sale_year) | class(min_sale_year)[1] == "numeric"){
+    min_sale_year <- paste0("&salesDateMin=", min_sale_year)
     
-    base_url <- paste0(base_url, min_sale_date)
+    base_url <- paste0(base_url, min_sale_year)
   } else {
-    stop("min_sale_date cannot be null and needs to be of class Date.")
+    stop("min_sale_year cannot be null and needs to be of class numeric.")
   }
   
-  if(!is.null(max_sale_date) | class(max_sale_date)[1] == "Date"){
-    max_sale_date <- paste0("&maxsaledate=", max_sale_date)
+  if(!is.null(max_sale_year) | class(max_sale_year)[1] == "numeric"){
+    max_sale_year <- paste0("&salesDateMax=", max_sale_year)
     
-    base_url <- paste0(base_url, max_sale_date)
+    base_url <- paste0(base_url, max_sale_year)
   } else {
-    stop("max_sale_date cannot be null and needs to be of class Date.")
+    stop("max_sale_year cannot be null and needs to be of class numeric.")
   }
   
   if(!is.null(type)){

--- a/R/boliga_webscrape_sold.R
+++ b/R/boliga_webscrape_sold.R
@@ -27,7 +27,6 @@ boliga_webscrape_sold <- function(min_sale_date, max_sale_date, type, postal_cod
     boliga_base_html %>% 
     rvest::html_node(".listings-found-text") %>% 
     rvest::html_text() %>%
-    #stringr::str_replace_all("[,.]") %>%
     readr::parse_number(locale = readr::locale(grouping_mark = ".")) %>% 
     as.integer()
   

--- a/R/boliga_webscrape_sold.R
+++ b/R/boliga_webscrape_sold.R
@@ -27,8 +27,8 @@ boliga_webscrape_sold <- function(min_sale_date, max_sale_date, type, postal_cod
     boliga_base_html %>% 
     rvest::html_node(".listings-found-text") %>% 
     rvest::html_text() %>%
-    stringr::str_replace_all("[,.]") %>%
-    readr::parse_number() %>% 
+    #stringr::str_replace_all("[,.]") %>%
+    readr::parse_number(locale = readr::locale(grouping_mark = ".")) %>% 
     as.integer()
   
   # There are 50 results per page

--- a/R/boliga_webscrape_sold.R
+++ b/R/boliga_webscrape_sold.R
@@ -4,16 +4,16 @@
 #' The function takes the search results from the base url
 #' and iterates until there's no "next" page.
 #'
-#' @param min_sale_date Sale date from.
-#' @param max_sale_date Sale date to.
+#' @param min_sale_year Sale year from as numeric.
+#' @param max_sale_year Sale year to as numeric.
 #' @param type Type.
 #' @param postal_code Postal code.
 #' @export
 #' @importFrom magrittr %>%
-boliga_webscrape_sold <- function(min_sale_date, max_sale_date, type, postal_code){
+boliga_webscrape_sold <- function(min_sale_year, max_sale_year, type, postal_code){
 
-  base_url <- boliga_create_base_url(min_sale_date = min_sale_date, 
-                                        max_sale_date = max_sale_date, 
+  base_url <- boliga_create_base_url(min_sale_year = min_sale_year, 
+                                        max_sale_year = max_sale_year, 
                                         type = type, 
                                         postal_code = postal_code)
   
@@ -27,7 +27,8 @@ boliga_webscrape_sold <- function(min_sale_date, max_sale_date, type, postal_cod
     boliga_base_html %>% 
     rvest::html_node(".listings-found-text") %>% 
     rvest::html_text() %>%
-    readr::parse_number(locale = readr::locale(grouping_mark = ".")) %>% 
+    stringr::str_replace_all(., "\\.", "") %>%
+    readr::parse_number() %>% 
     as.integer()
   
   # There are 50 results per page
@@ -48,8 +49,9 @@ boliga_webscrape_sold <- function(min_sale_date, max_sale_date, type, postal_cod
   result_list <- vector("list", page_count)
   for(page in 1:page_count){
     
-    url_address <- glue::glue('{base_url}', '&p={page}')
-    
+    url_address <- glue::glue('{base_url}', '&page={page}')
+    #print(url_address)
+  
     result_list[[page]] <- boliga_get_table(url_address)
     
     Sys.sleep(time = rgamma(n = 1, shape = 3, scale = 0.3))

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,18 +10,18 @@ bol_extract_table <- function(boliga_content){
   bol_table <-
     boliga_content %>%
     xml2::read_html() %>%
-    rvest::html_nodes(".mb-3") %>%
-    rvest::html_nodes("tr") %>%
-    purrr::map(~rvest::html_nodes(.x, "td"))
+    rvest::html_nodes("tbody") %>% 
+    rvest::html_nodes("tr") %>% 
+    purrr::map(~rvest::html_nodes(.x, "td")) 
 
   adresse <-
     bol_table %>%
-    purrr::map(~.x %>% .[1] %>% rvest::html_node("a")) %>%
+    purrr::map(~.x %>% .[1] %>% rvest::html_node("a")) %>% 
     purrr::map(~as.character(.x)) %>%
-    purrr::map(~stringr::str_replace_all(.x, "<br>", ", ")) %>%
+    purrr::map(~stringr::str_replace_all(.x, "<br>", ", ")) %>% 
     do.call(c, .) %>%
     paste(., collapse = "\n") %>%
-    xml2::read_html(.) %>%
+    xml2::read_html(.) %>%  
     rvest::html_nodes("a") %>%
     rvest::html_text()
 
@@ -39,9 +39,14 @@ bol_extract_table <- function(boliga_content){
     do.call(c, .) %>%
     as.Date(dato, format = "%d-%m-%Y")
 
-  boligtype <-
+  salgstype <-
     bol_table %>%
     purrr::map(~.x %>% .[3] %>% rvest::html_nodes("span") %>% .[2] %>% rvest::html_text() %>% stringr::str_replace_all(., "\\.", "")) %>%
+    do.call(c, .)
+
+  boligtype <-
+    bol_table %>%
+    purrr::map(~.x %>% .[1] %>% rvest::html_node("p") %>% .[1] %>% rvest::html_text() %>% stringr::str_replace_all(., "\\.", "") %>% stringr::str_trim()) %>%
     do.call(c, .)
 
   pris_kvm <-
@@ -81,7 +86,7 @@ bol_extract_table <- function(boliga_content){
 
   bolig_link_selected <- bolig_link[seq(4, length(bolig_link), 4)]
 
-  res_df <- dplyr::bind_cols(tibble::tibble(adresse, pris, salgsdato, boligtype, pris_kvm, vaerelser, m2, byggear))
+  res_df <- dplyr::bind_cols(tibble::tibble(adresse, pris, salgsdato, salgstype, boligtype, pris_kvm, vaerelser, m2, byggear))
   res_df$bolig_link <- bolig_link_selected
 
   res_df


### PR DESCRIPTION
Boliga.dk has changed several things on their page.
First they have changed the option of choosing exact date to look up houses old. It only supports year now.

They have also changed some of the structure of their HTML coding. This has been updated.

I have added a column to the final output containing _salgstype_ ("Alm Salg", "Familiesalg", etc.). This was named boligtype before. 
I added _boligtype_ ("Villa", "Landejendom", etc.). 

I also made a more robust solution to my earlier contribution where number of results now reads correctly.

The solution should work now for boliga_webscrape_sold.R.

**Attention**
The funciton for all (boliga_all_houses.R) is not working. 
Updates needed for:
- URL
- 50 results pr. page (instead of 40)

There might be more, but I am unsure whether the function is for all sold houses, or all houses for sale.